### PR TITLE
Fix travis by using supported Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 python:
-  - "2.7"
+  - "3.6"
 cache: pip
 services:
   - docker


### PR DESCRIPTION
instead of Python 2.7 which is unsupported
by ruamel.yaml 0.17+, that is installed for
running the tests.

Using Python 3 should be cool as it is supported
by all the tested Ansible versions (2.5+).